### PR TITLE
Install on a specified device

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Install and debug iPhone apps without using Xcode. Designed to work on unjailbro
 
 ## Usage
 
-* `fruitstrap [-d] <app>`
+* `fruitstrap [-d] <app> [device_id]`
 * Optional `-d` flag launches a remote GDB session after the app has been installed.
 * `<app>` must be an iPhone application bundle, *not* an IPA.
+* Optional device id, useful when you have more than one iPhone/iPad connected to your computer
 
 ## Demo
 


### PR DESCRIPTION
I've added support for installing an app on a device by specifying its device id. You need it if you are to install an app on an iPhone when more than one iPhone/iPad is connected to your machine.
