### PR TITLE
Fixes to number of arguments checking and added git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+demo
+demo.app
+fruitstrap

--- a/fruitstrap.c
+++ b/fruitstrap.c
@@ -366,7 +366,7 @@ void device_callback(struct am_device_notification_callback_info *info, void *ar
 }
 
 int main(int argc, char *argv[]) {
-    if (argc < 2 || argc > 3) {
+    if (argc < 2 || argc > 4) {
         printf("usage: %s [-d] <app> [device_id]\n", argv[0]);
         exit(1);
     }


### PR DESCRIPTION
I just pulled in the latest changes, and noticed I couldn't run with the -d flag as well as specific a device ID. It looks like it was just incorrectly bailing out when you specified all arguments.

I added a .gitignore file for the products that are built by make
