### PR TITLE
Detecting legacy and up-to-date xCode installation using xcode-select

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-IOS_CC = /Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/gcc
+
+
+XCODE_ROOT = $(shell xcode-select -print-path)
+IOS_CC = $(XCODE_ROOT)/Platforms/iPhoneOS.platform/Developer/usr/bin/gcc
 
 all: demo.app fruitstrap
 
@@ -9,7 +12,7 @@ demo.app: demo Info.plist
 	codesign -f -s "iPhone Developer" --entitlements Entitlements.plist demo.app
 
 demo: demo.c
-	$(IOS_CC) -arch armv7 -isysroot /Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.0.sdk -framework CoreFoundation -o demo demo.c
+	$(IOS_CC) -arch armv7 -isysroot $(XCODE_ROOT)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.0.sdk -framework CoreFoundation -o demo demo.c
 
 fruitstrap: fruitstrap.c
 	gcc -o fruitstrap -framework CoreFoundation -framework MobileDevice -F/System/Library/PrivateFrameworks fruitstrap.c


### PR DESCRIPTION
Replaced hard coded paths with xcode-select output.
Now "make fruitstrap" does the job for xCode4.3 as well.
