### PR TITLE
nonstop debugging, retries for pairing, useful for continuous integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ demo.app: demo Info.plist
 	codesign -f -s "iPhone Developer" --entitlements Entitlements.plist demo.app
 
 demo: demo.c
-	$(IOS_CC) -arch armv7 -isysroot /Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.0.sdk -framework CoreFoundation -o demo demo.c
+	$(IOS_CC) -arch armv7 -isysroot /Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.1.sdk -framework CoreFoundation -o demo demo.c
 
 fruitstrap: fruitstrap.c
 	gcc -o fruitstrap -framework CoreFoundation -framework MobileDevice -F/System/Library/PrivateFrameworks fruitstrap.c


### PR DESCRIPTION
add boolean option for nonstop debugging -n
runs immediately and exist, by passing a continue and quit command to gdb, avoid getting stuck in the debugging, useful for continuous integration

add integer option -r num for number of retries (default 20), so that if the pairing fails it just retries a few times, instead of exiting/asserting.

move from 5.0 to 5.1 sdk
